### PR TITLE
Implementar soporte para ignorar acciones con rutas completas

### DIFF
--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -23,12 +23,15 @@ class Traceroute
     @ignored_unused_routes << %r{^#{@app.config.assets.prefix}} if @app.config.respond_to? :assets
 
     config_filename = %w(.traceroute.yaml .traceroute.yml .traceroute).detect {|f| File.exist?(f)}
+    # Los if implementados dentro del loop es para limpiar ignored_action en caso de que se haya agregado una ruta completa al controlador
     if config_filename && (config = YAML.load_file(config_filename))
       (config['ignore_unreachable_actions'] || []).each do |ignored_action|
+        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if '/controllers/'.in?(ignored_action)
         @ignored_unreachable_actions << Regexp.new(ignored_action)
       end
 
       (config['ignore_unused_routes'] || []).each do |ignored_action|
+        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if '/controllers/'.in?(ignored_action)
         @ignored_unused_routes << Regexp.new(ignored_action)
       end
     end


### PR DESCRIPTION
## Issues relacionados

Fixes [PLAT-1554](https://buk.atlassian.net/browse/PLAT-1554)

## Descripción del problema

Actualmente en el Code Health Dashboard las rutas y acciones inutilizadas están procesándose como `unknown` para cada equipo. Esto nos hizo cuestionarnos posibles soluciones y la presentada aquí pretende mejorar la lectura de la gema para ignorar acciones/rutas inutilizadas.

## Qué se hizo para resolver problema

Ahora la gema puede leer rutas completas del archivo, no solo de la manera `nombre/controlador#accion`, ejemplo: `packs/plataforma/core_app/app/controllers/errors#not_found`

## Cómo probar.

* agregar en el archivo `.traceroute.yml` la nueva forma:`ruta_completa/controlador#accion` 
ejemplo packs/plataforma/core_app/app/controllers/errors#not_found
* En Postgres crear la base de datos: `code_health_metrics` y dar los permisos correspondientes
* Configurar la variable de entorno `CODE_HEALTH_DB_URL=postgres://buk:buk1234@localhost/code_health_metrics` en el archivo `.env.development.local`
* Usar el comando: `bin/code_health traceroute` o si quiere `debuggear` usar el comando `rails runner bin/code_health traceroute`
* En cualquier gestor de base de datos se puede verificar que la tabla `code_health_metrics` dentro de la base dadas creada se encuentra con la información de `traceroute`
* Utilizamos la siguiente consulta
```
SELECT
  count(*), team
FROM code_health_metrics
WHERE name = 'traceroute'
AND reported_at = (select max(reported_at) from code_health_metrics where name = 'traceroute')
group by team
```
y podemos generar el reporte de asignación por equipo.
